### PR TITLE
Fix `CalendarIdentifier` crash on iOS 16

### DIFF
--- a/Sources/Thumbmark/Thumbmark.swift
+++ b/Sources/Thumbmark/Thumbmark.swift
@@ -55,7 +55,7 @@ public extension Thumbmark {
                                 languageCode: Locale.current.languageCode,
                                 regionCode: Locale.current.regionCode,
                                 availableRegionCodes: Locale.isoRegionCodes.count,
-                                calendarIdentifier: Locale.current.calendar.identifier.debugDescription,
+                                calendarIdentifier: String(describing: Locale.current.calendar.identifier),
                                 timezone: TimeZone.current.identifier,
                                 availableTimezones: TimeZone.knownTimeZoneIdentifiers.count,
                                 availableKeyboards: UserDefaults.standard.array(forKey: "AppleKeyboards")?.count ?? 0,


### PR DESCRIPTION
This PR fixes a crash that was occurring on devices running iOS versions lower than 17.0

```
dyld[36075]: Symbol not found: _$s10Foundation8CalendarV10IdentifierO16debugDescriptionSSvg
  Referenced from: <89A885DF-A0B5-3142-B4CB-92E1605BAEC1> 
```